### PR TITLE
Set LC_ALL for upower

### DIFF
--- a/battstat
+++ b/battstat
@@ -41,7 +41,7 @@ get_darwin_details() {
 }
 
 get_linux_details() {
-    battery_details=$(upower -i $(upower -e | grep 'BAT'))
+    battery_details=$(LC_ALL=en_US.UTF-8 upower -i $(upower -e | grep 'BAT'))
     
     # Exit if no batery exists.
     if [ -z "$battery_details" ]; then


### PR DESCRIPTION
That way, the parsing after doesn't depend on the locale of the user.

Fixes https://github.com/imwally/battstat/issues/3.