### PR TITLE
Support overrideing icons with the default format

### DIFF
--- a/battstat
+++ b/battstat
@@ -2,6 +2,7 @@
 
 charging_icon="⚡"     #  U+26A1 - Thunderbolt
 discharging_icon="🔋" # U+1F50B - Battery
+format=false  # Track whether formatting was supplied from the user
 
 print_help() {
     echo "usage: battstat [options] format"
@@ -169,11 +170,6 @@ case $(uname) in
 	;;
 esac
 
-if [ $# -eq 0 ]; then
-    print_time
-    print_percent
-    print_icon
-fi
 
 while test $# -gt 0; do
     case "$1" in
@@ -192,14 +188,17 @@ while test $# -gt 0; do
 	    shift
 	    ;;
 	{i})
+        format=true
 	    print_icon
 	    shift
 	    ;;
 	{t})
+        format=true
 	    print_time
 	    shift
 	    ;;
 	{p})
+        format=true
 	    print_percent
 	    shift
 	    ;;
@@ -209,5 +208,13 @@ while test $# -gt 0; do
 	    ;;
     esac
 done
+
+if [ "$format" = false ]
+then
+    # No format was provided by the user, so print the default format
+    print_time
+    print_percent
+    print_icon
+fi
 
 printf "\n"


### PR DESCRIPTION
Battstat has a default format that it prints if the user does not provide one. However, it is broken if the user provides an override for the charging or discharging icons.

This patch fixes this and supports the default format with icon overrides (fixes #7).

Example of the new support (note - the preexec and postexec messages are a separate tool I use):
![Screenshot from 2023-09-22 11-08-14](https://github.com/imwally/battstat/assets/65743084/ed25ccae-ab57-4bb9-b7a7-befa5222784d)

